### PR TITLE
Disable Github Actions if not in the source repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == "rydixulous/Discord-Resources-n-More" }}
+    if: ${{ github.repository == 'rydixulous/Discord-Resources-n-More' }}
     steps:
       - uses: actions/checkout@v1
       # Additional steps to generate documentation in "Wiki_Files" directory

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,12 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == "rydixulous/Discord-Resources-n-More" }}
     steps:
       - uses: actions/checkout@v1
       # Additional steps to generate documentation in "Wiki_Files" directory
       - name: Upload Documentation to Wiki
         uses: SwiftDocOrg/github-wiki-publish-action@v1
-        if: ${{ github.repository == "rydixulous/Discord-Resources-n-More" }}
         with:
           path: "Wiki_Files"
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,11 @@
 name: Publish changes to the wiki
 
-on: [push] if: ${{ }}
+on: [push]
 
 jobs:
   build:
+    if: ${{ github.repository == "rydixulous/Discord-Resources-n-More" }}
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v1
       # Additional steps to generate documentation in "Documentation" directory

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,14 +4,13 @@ on: [push]
 
 jobs:
   build:
-    if: ${{ github.repository == "rydixulous/Discord-Resources-n-More" }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      # Additional steps to generate documentation in "Documentation" directory
+      # Additional steps to generate documentation in "Wiki_Files" directory
       - name: Upload Documentation to Wiki
         uses: SwiftDocOrg/github-wiki-publish-action@v1
-        
+        if: ${{ github.repository == "rydixulous/Discord-Resources-n-More" }}
         with:
           path: "Wiki_Files"
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Publish changes to the wiki
 
-on: [push]
+on: [push] if: ${{ }}
 
 jobs:
   build:
@@ -11,6 +11,7 @@ jobs:
       # Additional steps to generate documentation in "Documentation" directory
       - name: Upload Documentation to Wiki
         uses: SwiftDocOrg/github-wiki-publish-action@v1
+        
         with:
           path: "Wiki_Files"
         env:

--- a/Wiki_Files/Resources.md
+++ b/Wiki_Files/Resources.md
@@ -940,4 +940,3 @@ https://thispersondoesnotexist.com/ | this person does not exist
 
 
 
-


### PR DESCRIPTION
This is a simple QOL improvement to stop the Github Action (`main.yml`) if the repository is not this repository. It won't stop it from running (that's something the fork repo owner would have to change), but it will stop it from failing.