### PR TITLE
Added a section about running the wiki at home

### DIFF
--- a/wiki/about.md
+++ b/wiki/about.md
@@ -40,6 +40,24 @@ We want to thank: <br/>
 **Rydix#1726** (755792681313108018) - *I had this idea and did all of the above* 
 
 ## Contribution
-Found an error or a typo? Have a good resource that fits this list? Become a contributor on be on the glorious list of contributors above! <br/>
+Found an error or a typo? Have a good resource that fits this list? Become a contributor and be on the glorious list of contributors above! <br/>
 To contribute, you are more than welcome to PR this wiki or send a DM to Rydix#1726 (755792681313108018) in order to edit the wiki, and yourself into the list.
 You can also join the [Official Project Guild](https://discord.gg/yxbqz9pNxS) to contribute there.
+
+## How to test changes locally
+Got a great PR going but don't know what it looks like? Not a problem! <br/>
+If you're in a fork of the repository it's as easy as running these 2 commands:
+```
+npm install
+```
+This downloads all the repositories needed by our documentation system (Docusaurus). You only need to run this once.
+```
+npm start
+```
+This command starts the web server (``localhost:3000`` by default) and must be ran every time you want to start editing. 
+It does not need to be ran for every change you make however, as Docusaurus will automatically restart the server if it detects changes!
+
+Once you've got a running instance of the website locally, you're ready to start contributing! 
+Notes: Please use ``<br/>`` for line break characters<br/>
+Requires Node.js version >= ``12.13.0`` 
+If you are using Yarn: Yarn version >= ``1.5``


### PR DESCRIPTION
I've added a section to the about page that includes basic instructions for contributing to the wiki. It has info on installing the necessary packages and how to run the webserver on localhost.