### PR TITLE
Update invite widget when theme is changed

### DIFF
--- a/src/components/InviteWidget.jsx
+++ b/src/components/InviteWidget.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import useThemeContext from '@theme/hooks/useThemeContext'
+
+export default function InviteWidget({invite}) {
+    const {isDarkTheme} = useThemeContext();
+
+    return (
+        <a href={`https://discord.gg/${invite}`} target="_blank">
+            <img src={`https://invidget.switchblade.xyz/${invite}?theme=${isDarkTheme ? 'dark' : 'light'}`} alt=""/>
+        </a>
+    )
+}

--- a/wiki/resources/official-servers.md
+++ b/wiki/resources/official-servers.md
@@ -2,29 +2,31 @@
 sidebar_position: 2
 ---
 
+import InviteWidget from '/src/components/InviteWidget.jsx'
+
 # Official Servers
 
 ## **Discord Testers** 
 > __Description:__ The official place to report Discord Bugs! Help find bugs, chat with others and be a part of the testers community!   <br/>
 __Link:__ [Discord Testers](https://discord.gg/discord-testers)
 
-[![Discord Testers](https://invidget.switchblade.xyz/discord-testers)](https://discord.gg/discord-testers)
+<InviteWidget invite="discord-testers"/>
 
 
 ## **Discord Developers**
 > __Description:__ The official place to discuss Discord's API and SDKs with community developers and Discord staff alike!   <br/>
 __Link:__ [Discord Developers](https://discord.gg/discord-developers)
 
-[![Discord Developers](https://invidget.switchblade.xyz/discord-developers)](https://discord.gg/discord-developers)
+<InviteWidget invite="discord-developers"/>
 
 ## **Discord Townhall** 
 > __Description:__ An official general chatting server for people who love Discord.  Find the latest news, events, and a community you love!   <br/>
 __Link:__ [Discord Townhall](https://discord.gg/discord-townhall)
 
-[![Discord Townhall](https://invidget.switchblade.xyz/discord-townhall)](https://discord.gg/discord-townhall)
+<InviteWidget invite="discord-townhall"/>
 
 ## **Discord Games Lab** 
 > __Description:__ The official server for Discord's Games Lab. Come play Poker Night, Chess, or Watch Together with your friends!   <br/>
 __Link:__ [Discord Games Lab](https://discord.gg/discordgameslab)
 
-[![Discord Games Lab](https://invidget.switchblade.xyz/discordgameslab)](https://discord.gg/discordgameslab)
+<InviteWidget invite="discordgameslab"/>

--- a/wiki/resources/unofficial-servers.md
+++ b/wiki/resources/unofficial-servers.md
@@ -2,6 +2,8 @@
 sidebar_position: 8
 ---
 
+import InviteWidget from '/src/components/InviteWidget.jsx'
+
 # Unofficial Servers
 
 ## **Discord API**
@@ -9,28 +11,28 @@ sidebar_position: 8
 __Link:__ [Discord API](https://discord.gg/discord-api)   <br/>
 __Credit:__ Discord API team (owned by Danny#0007 | 80088516616269824)
 
-[![Discord API](https://invidget.switchblade.xyz/discord-api)](https://discord.gg/discord-api)
+<InviteWidget invite="discord-api"/>
 
 ## **Discord Linux**
 > __Description:__ A server dedicated to information and assistance with the Linux version of Discord.   <br/>
 __Link:__ [Discord Linux](https://discord.gg/discord-linux)   <br/>
 __Credit:__ Discord Linux team (owned by Syretia#4268 | 86201442112671744)
 
-[![Discord Linux](https://invidget.switchblade.xyz/discord-linux)](https://discord.gg/discord-linux)
+<InviteWidget invite="discord-linux"/>
 
 ## **Discord Bots**
 > __Description:__ The Discord server for the oldest bots list on Discord, affiliated with Discord API.   <br/>
 __Link:__ [Discord Bots](https://discord.gg/dbots)   <br/>
 __Credit:__ Discord Bots’ server team (owned by meew0#9811 | 66237334693085184)
 
-[![Discord Bots](https://invidget.switchblade.xyz/dbots)](https://discord.gg/dbots)
+<InviteWidget invite="dbots"/>
 
 ## **Discord Networking**
 > __Description:__ A place where anyone that helps support the operation of a Discord server can get to know each other, exchange advice, and create lasting partnerships.   <br/>
 __Link:__ [Discord Networking](https://discord.gg/BcXExxeGVG) (Access request required)   <br/>
 __Credit:__ Discord Networking team (owned by NaviKing#3820 | 200987752794292224)
 
-[![Discord Networking](https://invidget.switchblade.xyz/BcXExxeGVG)](https://discord.gg/BcXExxeGVG)
+<InviteWidget invite="BcXExxeGVG"/>
 
 
 ## **Displace** 
@@ -38,14 +40,14 @@ __Credit:__ Discord Networking team (owned by NaviKing#3820 | 200987752794292224
 __Link(s):__ [Displace server](https://discord.gg/displace) | [Displace Website](https://dat.place/)   <br/>
 __Credit:__ The Displace team (owned by Panley#8008 | 249287049482338305)
 
-[![Displace](https://invidget.switchblade.xyz/displace)](https://discord.gg/displace)
+<InviteWidget invite="displace"/>
 
 ## **The Coding Den**
 > __Description:__  The Coding Den is a friendly community of coders focusing on helping new and experienced programmers alike.   <br/>
 __Link:__ [The Coding Den](https://discord.gg/code)   <br/>
 __Credit:__ The Coding Den team (owned by obliv1on#1337 | 229334929614438400)
 
-[![The Coding Den](https://invidget.switchblade.xyz/code)](https://discord.gg/code)
+<InviteWidget invite="code"/>
 
 ## **Discord Hotline**
 > __Description:__ A community for moderators to discuss moderation and Discord Meta.   <br/>


### PR DESCRIPTION
The invite widgets now update with the selected theme. 
Website in light theme -> widgets in light theme
Website in dark theme -> widgets in dark theme

View preview at: https://discord-resources.pages.dev/resources/unofficial-servers/ (make sure to try switching the theme)