### PR TITLE
  ❌ Remove Powercord

### DIFF
--- a/wiki/resources/tools/discord.md
+++ b/wiki/resources/tools/discord.md
@@ -113,10 +113,6 @@ __Credit:__ Mozzy#9999 (99182302885588992)
 __Link:__ [Webence](https://panleyent.com/webence/)   <br/>
 __Credit:__  Panley#8008 (249287049482338305)
 
-### **Powercord**
-> __Description:__ Powercord is a lightweight client mod focused on simplicity and performance.   <br/>
-__Link:__ [Powercord](https://powercord.dev/)
-
 ### **Presence Maker**
 > __Description:__ Create Discord rich presence with this tool.   <br/>
 __Link:__ [Presence Maker](https://github.com/ThatOneCalculator/DiscordRPCMaker)


### PR DESCRIPTION
Client modifications are against ToS. Therefore it should be removed from the Discord resources wiki as some users may be lured into using it, without knowing it could be against ToS. In the worst case scenario, these users would be banned from using Discord without understanding why.